### PR TITLE
[FIX] redirect uri path - PIT-428

### DIFF
--- a/src/main/java/PitterPatter/loventure/authService/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/PitterPatter/loventure/authService/handler/OAuth2LoginSuccessHandler.java
@@ -91,10 +91,10 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         log.info("OAuth2 콜백 URI: {}", requestURI);
         
         // OAuth2 콜백 URL에서 provider 정보 추출 (정확한 패턴 매칭)
-        if (requestURI.equals("/oauth2/code/google") || requestURI.contains("/oauth2/code/google")) {
+        if (requestURI.equals("/login/oauth2/code/google") || requestURI.contains("/login/oauth2/code/google")) {
             log.info("Google OAuth2 콜백 감지");
             return "google";
-        } else if (requestURI.equals("/oauth2/code/kakao") || requestURI.contains("/oauth2/code/kakao")) {
+        } else if (requestURI.equals("/login/oauth2/code/kakao") || requestURI.contains("/login/oauth2/code/kakao")) {
             log.info("Kakao OAuth2 콜백 감지");
             return "kakao";
         }

--- a/src/main/java/PitterPatter/loventure/authService/security/SecurityConfig.java
+++ b/src/main/java/PitterPatter/loventure/authService/security/SecurityConfig.java
@@ -81,7 +81,7 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/login/**", "/oauth2/**", "/api/test/**", "/api/auth/status",
+                        .requestMatchers("/", "/api/test/**", "/api/auth/status",
                                 "/api/auth/signup", "/api/auth/login/**", "/api/auth/oauth2/**",
                                 "/api/auth/swagger-ui/**", "/api/auth/v3/api-docs/**", "/api/auth/swagger-ui.html",
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/actuator/**").permitAll() // 누구나 접근 가능한 경로


### PR DESCRIPTION
## 📝 목적/배경
- 왜 이 변경이 필요한가? 어떤 문제를 해결하는가?
기존 배포 환경에서 oauth2 접근 시, 404 error 발생
-> application-prod.yml의 context-path에 /api/auth 설정으로 자동으로 해당 주소가 붙은 것으로 확인하여 해당 부분 수정
## 🔧 주요 작업(변경) 사항
- [ ] Login2OAuthSuccessHandler, SecurityConfig 파일에 존재했던 path 수정

## 🎥 스크린샷/데모 (선택)
<이미지 또는 gif>

## 🔗 이슈 연결
- PIT-428

## ✅ 체크리스트
- [ ] merge branch 가 develop 인지 확인
- [ ] 모든 코드가 잘 작동하는지 확인
- [ ] 모두가 알아 볼 수 있도록 작성 되어 있는지

## 📌 기타
